### PR TITLE
Improve invitation answer response time

### DIFF
--- a/application/bot/src/api/bot_api.py
+++ b/application/bot/src/api/bot_api.py
@@ -414,6 +414,34 @@ class BotApi:
                 del block["text"]["emoji"]
         return blocks
 
+    def send_pizza_invite_loading(self, channel_id, ts, old_blocks, event_id, slack_client):
+        self.logger.info('updating invitation message to LOADING for %s, %s' % (channel_id, event_id))
+        new_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ":hourglass_flowing_sand: Behandler forespørselen din...",
+                }
+            }
+        ]
+        blocks = old_blocks + new_blocks
+        return slack_client.update_slack_message(channel_id=channel_id, ts=ts, blocks=blocks)
+
+    def send_pizza_invite_not_among_invited_users(self, channel_id, ts, old_blocks, event_id, slack_client):
+        self.logger.info('updating invitation message to not among invited for %s, %s' % (channel_id, event_id))
+        new_blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Kunne ikke oppdatere invitasjonen. Du var ikke blant de inviterte.",
+                }
+            }
+        ]
+        blocks = old_blocks + new_blocks
+        return slack_client.update_slack_message(channel_id=channel_id, ts=ts, blocks=blocks)
+
     def send_update_pizza_invite_attending(self, channel_id, ts, event_id, slack_client):
         self.logger.info('updating invitation message to attending for %s, %s' % (channel_id, event_id))
         invitation_message = slack_client.get_slack_message(channel_id, ts)

--- a/application/bot/src/slack/__init__.py
+++ b/application/bot/src/slack/__init__.py
@@ -121,6 +121,10 @@ def handle_rsvp_withdraw(ack, body, context):
     ts = message['ts']
     blocks = message["blocks"][0:3]
     with injector.get(BotApi) as ba:
+        # Send loading message and acknowledge the slack request
+        ba.send_pizza_invite_loading(channel_id=channel_id, ts=ts, old_blocks=blocks, event_id=event_id, slack_client=client)
+        ack()
+        # Try to withdraw the user
         success = ba.withdraw_invitation(event_id=event_id, slack_id=user_id)
         if success:
             logger.info("%s withdrew their invitation", user_id)
@@ -128,7 +132,6 @@ def handle_rsvp_withdraw(ack, body, context):
         else:
             logger.warning("failed to withdraw invitation for %s", user_id)
             ba.send_pizza_invite_withdraw_failure(channel_id=channel_id, ts=ts, old_blocks=blocks, slack_client=client)
-    ack()
 
 def handle_file_share(event, say, token, client):
     channel = event["channel"]
@@ -153,6 +156,7 @@ def handle_file_share(event, say, token, client):
 
 @slack_app.command("/set-pizza-channel")
 def handle_some_command(ack, body, say, context):
+    ack()
     with injector.get(BotApi) as ba:
         team_id = body["team_id"]
         message_channel_id = body["channel_id"]
@@ -170,7 +174,6 @@ def handle_some_command(ack, body, say, context):
                 text='Pizza kanal er nå satt til <#%s>' % channel_id,
                 slack_client=client
             )
-    ack()
 
 # This only exists to make bolt not throw a warning that we dont handle the file_shared event
 # We dont use this as we use the message event with subtype file_shared as that one


### PR DESCRIPTION
closes https://github.com/blankoslo/Pizza.v2/issues/117

might fix aswell https://github.com/blankoslo/Pizza.v2/issues/46

hopefully this lowers the response time by not handling invitation updates before sending the ack. Still possible that it might be too slow if getting a connection when using the bot client with `with x as y:`. If so do the loading message and ack before getting a connection.